### PR TITLE
Resolve the issue that rules with '*' selector  always got removed ev…

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = postcss.plugin('postcss-mpvue-wxss', function (options) {
         }
       }
     });
-    
+
     root.walkRules(rule => {
       const { selector } = rule || {};
 
@@ -54,7 +54,7 @@ module.exports = postcss.plugin('postcss-mpvue-wxss', function (options) {
         selectors.each(function (selector) {
           selector.each(function (n) {
             // 转换 tag 选择器
-            if (n.type === 'tag') {
+            if (n.type === 'tag'||n.type === 'universal') {
               const k = n.value;
               const v = options.replaceTagSelector[k];
               if (v) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -139,6 +139,9 @@ it('test replaceTagSelector with options', () => {
     }
     bbb {
       width: 60rpx;
+    }
+    * {
+      box-sizing: border-box;
     }`;
   const output = `
     ._aaa {
@@ -146,11 +149,15 @@ it('test replaceTagSelector with options', () => {
     }
     ccc, .ddd {
       width: 60rpx;
+    }
+    view, text {
+      box-sizing: border-box;
     }`;
   const options = {
     replaceTagSelector: {
       aaa: 'replaceToClass',
-      bbb: 'ccc, .ddd'
+      bbb: 'ccc, .ddd',
+      '*': 'view, text'
     }
   };
   return run(input, output, options);


### PR DESCRIPTION
…en if overwritten in replaceTagSelector (see change of index.test.js)

修正了replaceTagSelector参数的覆盖对“*”选择器不起作用的问题